### PR TITLE
(feat): add max limit for gemini extraction

### DIFF
--- a/backend/feddersen/config.py
+++ b/backend/feddersen/config.py
@@ -4,6 +4,8 @@
 # This is in an extra file so that the import works and does not cause a circular import.
 EXTRA_MIDDLEWARE_METADATA_KEY = "middleware_metadata"
 
+PDF_EXTRACTION_GEMINI_PAGE_LIMIT = 20
+
 # Configuration for the GeminiLoader
 LITELLM_GEMINI_NAME = "gemini-2.0-flash"
 GEMINI_PDF_EXCTRACTION_PROMPT = """

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -18,10 +18,11 @@ from langchain_community.document_loaders import (
     UnstructuredXMLLoader,
 )
 from langchain_core.documents import Document
+from pypdf import PdfReader
 
 from open_webui.retrieval.loaders.mistral import MistralLoader
-
 from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from feddersen.config import PDF_EXTRACTION_GEMINI_PAGE_LIMIT
 from feddersen.loaders.gemini import GeminiLoader
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
@@ -241,8 +242,12 @@ class Loader:
             )
         else:
             if file_ext == "pdf":
-                if self.kwargs.get("LITELLM_BASE_URL") and self.kwargs.get(
-                    "LITELLM_API_KEY"
+                # This is not yet rendering all pages but rather the format
+                num_pages = PdfReader(file_path).get_num_pages()
+                if (
+                    self.kwargs.get("LITELLM_BASE_URL")
+                    and self.kwargs.get("LITELLM_API_KEY")
+                    and num_pages <= PDF_EXTRACTION_GEMINI_PAGE_LIMIT
                 ):
                     loader = GeminiLoader(
                         base_url=self.kwargs.get("LITELLM_BASE_URL"),


### PR DESCRIPTION
Gemini can only handle < 1000 pages in a pdf and also costs some money and time to create a response. These very large documents ( >20 right now) will be extracted with the default PDF Extraction method.